### PR TITLE
return native implementation if it is supported

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var numberIsNaN = function (value) {
 	return value !== value;
 };
 
-module.exports = function is(a, b) {
+module.exports = Object.is || function is(a, b) {
 	if (a === 0 && b === 0) {
 		return 1 / a === 1 / b;
 	} else if (a === b) {
@@ -16,4 +16,3 @@ module.exports = function is(a, b) {
 	}
 	return false;
 };
-


### PR DESCRIPTION
If `Object.is` method already exists, it would be better to reuse native implementation.
For instance, it happens in similar [Object.assign](https://github.com/sindresorhus/object-assign) ponyfill. Same for [core-js version of Object.is](https://github.com/zloirock/core-js/blob/master/modules/_same-value.js) 
