### PR TITLE
feat: publish ESModule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,18 @@
 {
 	"root": true,
 
-	"extends": "@ljharb"
+	"extends": "@ljharb",
+	"parserOptions": {
+		"ecmaVersion": 6,
+		"sourceType": "module"
+	},
+	"overrides": [
+		{
+			"files": ["test/**/*.js"],
+			"parserOptions": {
+				"ecmaVersion": 5,
+				"sourceType": "script"
+			}
+		}
+	]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ node_modules
 npm-shrinkwrap.json
 package-lock.json
 yarn.lock
+
+# dist
+index.cjs

--- a/index.js
+++ b/index.js
@@ -1,12 +1,10 @@
-'use strict';
-
 // http://www.ecma-international.org/ecma-262/6.0/#sec-object.is
 
 var numberIsNaN = function (value) {
 	return value !== value;
 };
 
-module.exports = function is(a, b) {
+export default function is(a, b) {
 	if (a === 0 && b === 0) {
 		return 1 / a === 1 / b;
 	}
@@ -17,5 +15,5 @@ module.exports = function is(a, b) {
 		return true;
 	}
 	return false;
-};
+}
 

--- a/package.json
+++ b/package.json
@@ -7,10 +7,13 @@
 		"url": "https://github.com/sponsors/ljharb"
 	},
 	"license": "MIT",
-	"main": "index.js",
+	"main": "index.cjs",
+	"module": "index.js",
 	"scripts": {
-		"prepublish": "safe-publish-latest",
+		"build": "babel index.js --out-file index.cjs",
+		"prepublish": "safe-publish-latest && npm run build",
 		"pretest": "npm run lint",
+		"pretests-only": "npm run build",
 		"tests-only": "node test",
 		"test": "npm run tests-only",
 		"posttest": "npx aud",
@@ -39,8 +42,12 @@
 	],
 	"dependencies": {},
 	"devDependencies": {
+		"@babel/cli": "^7.8.4",
+		"@babel/core": "^7.8.4",
+		"@babel/plugin-transform-modules-commonjs": "^7.8.3",
 		"@ljharb/eslint-config": "^16.0.0",
 		"auto-changelog": "^1.16.2",
+		"babel-plugin-add-module-exports": "^1.0.2",
 		"covert": "^1.1.1",
 		"eslint": "^6.8.0",
 		"has-symbols": "^1.0.1",
@@ -75,5 +82,16 @@
 		"unreleased": false,
 		"commitLimit": false,
 		"backfillLimit": false
+	},
+	"babel": {
+		"plugins": [
+			[
+				"@babel/plugin-transform-modules-commonjs",
+				{
+					"strict": true
+				}
+			],
+			"add-module-exports"
+		]
 	}
 }


### PR DESCRIPTION
Publishes an esmodule build (`module`) alongside the commonjs (`main`) build.

Using [`babel-plugin-add-module-exports`](https://www.npmjs.com/package/babel-plugin-add-module-exports) should result in the best possible backwards compatibility.

<details>
<summary>`main` entry point `index.cjs` compared against `index.js` from `master`</summary>

```patch
diff --git a/index.js b/index.js
index 46b9710..ff8ec6b 100644
--- a/index.js
+++ b/index.js
@@ -1,21 +1,26 @@
-'use strict';
+"use strict";
 
-// http://www.ecma-international.org/ecma-262/6.0/#sec-object.is
+exports.default = is;
 
+// http://www.ecma-international.org/ecma-262/6.0/#sec-object.is
 var numberIsNaN = function (value) {
-	return value !== value;
+  return value !== value;
 };
 
-module.exports = function is(a, b) {
-	if (a === 0 && b === 0) {
-		return 1 / a === 1 / b;
-	}
-	if (a === b) {
-		return true;
-	}
-	if (numberIsNaN(a) && numberIsNaN(b)) {
-		return true;
-	}
-	return false;
-};
+function is(a, b) {
+  if (a === 0 && b === 0) {
+    return 1 / a === 1 / b;
+  }
+
+  if (a === b) {
+    return true;
+  }
+
+  if (numberIsNaN(a) && numberIsNaN(b)) {
+    return true;
+  }
+
+  return false;
+}
 
+module.exports = exports.default;

```
</details>